### PR TITLE
Remove INSTALL_NAME_DIR target property

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,6 @@ qt4_wrap_cpp(moc_srcs
 add_library(ctkPythonConsole ${srcs} ${moc_srcs})
 target_link_libraries(ctkPythonConsole ${QT_LIBRARIES} ${PYTHON_LIBRARIES} ${PYTHONQT_LIBRARIES})
 set_target_properties(ctkPythonConsole PROPERTIES SOVERSION 1.0 VERSION 1.0)
-set_target_properties(ctkPythonConsole  PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
 
 add_executable(console main.cpp)
 target_link_libraries(console ctkPythonConsole)


### PR DESCRIPTION
Using INSTALL_NAME_DIR target property forces the install name to be an
absolute path instead of `@rpath/{target_name}` [1]. This causes problems
when one tries to relocate the target once it is installed.
This patch removes this target property. If a project needs to keep
the absolute path, CMake variables such as INSTALL_NAME_DIR can be set at
configuration to do so.

[1] https://gitlab.kitware.com/cmake/cmake/issues/16589